### PR TITLE
Ensure mock has event emitter methods

### DIFF
--- a/test/SafeModule-test.js
+++ b/test/SafeModule-test.js
@@ -163,6 +163,21 @@ describe('SafeModule', () => {
     expect(result.emitter).instanceOf(NativeEventEmitter);
   });
 
+  it('mock has EventEmitter methods when isEventEmitter=true', () => {
+    const moduleName = uniqueModuleName();
+    const mock = {
+      foo: sinon.spy(),
+    };
+    const result = SafeModule.create({
+      moduleName,
+      mock,
+      isEventEmitter: true,
+    });
+    expect(result.emitter).instanceOf(NativeEventEmitter);
+    expect(result.addListener).to.be.a('function');
+    expect(result.removeListeners).to.be.a('function');
+  });
+
   it('falls back to older module name if newer name isnt present', () => {
     const moduleName1 = uniqueModuleName();
     const moduleName2 = uniqueModuleName();


### PR DESCRIPTION
On iOS, calling `addListener()` or `removeAllListeners()` on a
`NativeEventEmitter` instance also calls `addListener()` or
`removeListeners()` methods on the native module object passed into it.
If those methods aren't present, `NativeEventEmitter` will throw an
error. This was the case when the native module wasn't present on iOS,
and the mock was used, because the mock didn't contain `addListener()`
or `removeListeners()`.

The fix is to add those methods to the mock when `isEventEmitter` is
true.

to: @lelandrichardson 